### PR TITLE
Update README.md: Add link to blog and website

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
-# badestellen
-demo application
+# badegewaesser-berlin.de
+
+- [Website](https://badegewaesser-berlin.de/)
+- [Launch-Blogpost](https://lab.technologiestiftung-berlin.de/projects/bathing-water/index.html)

--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
 
+# Badestellen a.k.a. badegewaesser-berlin.de
+
+- [Website](https://badegewaesser-berlin.de/)
+- [Launch-Blogpost](https://lab.technologiestiftung-berlin.de/projects/bathing-water/index.html)
+
+## Support
+
+We are part of BrowserStack's non-profit program, helping us deliver an even better user experience.
+
+<a href="https://www.browserstack.com/">
+  <img src="https://p14.zdusercontent.com/attachment/1015988/Hjnr3apa9OCplUi1GbaLiCVa7?token=eyJhbGciOiJkaXIiLCJlbmMiOiJBMTI4Q0JDLUhTMjU2In0..QA4hJSE7NQfMjFDK1w6tog.0-YOVfCRjxpeHUf5tjKutEEoQn-U5peEUgQ6ZxBZugOJrShlKGm0lCgAURhV9T8Y-dIiFS9xTpdJ0UVPzSL1k4ka4emU3lzjerjHwhHt3Yl65Fs3S4JUWOhHvmiiG9-C0DvY7PJAEpwtGMNf-auRy84MUiYSMIriQzwkTTBJ7rdm7laryRnCGntFYfhs_GgGK38QEk8ZUhmx6M45yPoGTYrwjFPN85D3YmUA1zsEYEYKpIYOE2zdWT38wtQ6yyNWFTi6GyVQZ-p8nXAGbE5ZQR8XlKU2CquvZurSDtFeWhM.BIRFSvq27MoywSgtua3tYw" height="100">
+</a>


### PR DESCRIPTION
I think most projects at https://github.com/technologiestiftung/ can improve the links they have from GitHub to the actual project. 

Especially …
- Repo-Readme - this PR
- Github-Repo-Link – missing
- Github-Repo-Description – for this Repo
  > demo application
- Github-Repo-Tags – missing

Viele Grüße